### PR TITLE
Fixed "unexpected keyword" error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pyrogram
-tgcrypto
+pyrogram==1.2.9
+tgcrypto==1.2.2
 httplib2
 oauth2client
 google-api-python-client


### PR DESCRIPTION
Fixed this error:👇

 Traceback (most recent call last):
   File "/app/.heroku/python/lib/python3.9/runpy.py", line 197, in _run_module_as_main
     return _run_code(code, main_globals, None,
   File "/app/.heroku/python/lib/python3.9/runpy.py", line 87, in _run_code
     exec(code, run_globals)
   File "/app/bot/__main__.py", line 13, in <module>
     UtubeBot().run()
   File "/app/bot/utubebot.py", line 8, in __init__
     super().__init__(
 TypeError: __init__() got an unexpected keyword argument 'session_name'